### PR TITLE
Fixed spelling errors in status messages.

### DIFF
--- a/api/middleware/animal.js
+++ b/api/middleware/animal.js
@@ -47,7 +47,7 @@ module.exports = {
         }
 
         if (await animal_qry.first()) {
-          res.status(404).json({ message: 'Animal alreday exist' });
+          res.status(404).json({ message: 'Animal already exists.' });
         } else {
           next();
         }

--- a/api/middleware/animalService.js
+++ b/api/middleware/animalService.js
@@ -102,7 +102,7 @@ module.exports = {
           .where('service_id', service_id);
 
         if (await service_qry.first()) {
-          res.status(404).json({ message: 'Animal Service alreday exist' });
+          res.status(404).json({ message: 'Animal Service already exists.' });
         } else {
           next();
         }

--- a/api/middleware/service.js
+++ b/api/middleware/service.js
@@ -44,7 +44,7 @@ module.exports = {
         }
 
         if (await service_qry.first()) {
-          res.status(404).json({ message: 'Service alreday exist' });
+          res.status(404).json({ message: 'Service already exists.' });
         } else {
           next();
         }


### PR DESCRIPTION
There was a spelling and grammar error the status message included in 3 different files. The word "already" was spelled wrong and the word "exist" needed to be "exists" to be grammatically correct.