### PR TITLE
Changed the middleware to only require appointment_date_time column

### DIFF
--- a/api/middleware/appointment.js
+++ b/api/middleware/appointment.js
@@ -2,8 +2,7 @@ const requiredAppointmentInfo = [
   'groomer_id',
   'pet_id',
   'location_service_id',
-  'appointment_date',
-  'appointment_time',
+  'appointment_date_time',
   'status',
 ];
 


### PR DESCRIPTION
## Description
The appointment middleware was asking for two separate date and time columns, this has been fixed
Type
- [x] This is a bugfix.
- [ ] This is a new feature.
- [ ] This is part of a feature.
## Organization
- [ ] Have you linked this pull request to a Trello card?
- [x] Have you named the branch in the format of feature/describe_feature_or_change OR bug/describe_bug_this_is_fixing
## Review
- [ ] Is this a work in progress?
- [x]  Is this ready to be reviewed?
- [ ]  Have you added two reviewers to this pull request?
